### PR TITLE
Update fmt to 11.0

### DIFF
--- a/.github/workflows/build-ndk.yml
+++ b/.github/workflows/build-ndk.yml
@@ -70,14 +70,14 @@ jobs:
           files=( $pattern )
           echo ::set-output name=NAME::"${files[0]}"
       - name: Upload non-debug artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.libname.outputs.NAME }}
           path: ./build/${{ steps.libname.outputs.NAME }}
           if-no-files-found: error
 
       - name: Upload qmod artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{env.qmodName}}.qmod
           path: ./${{ env.qmodName }}.qmod

--- a/qpm.json
+++ b/qpm.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.1.0",
   "sharedDir": "shared",
   "dependenciesDir": "extern",
   "info": {
@@ -8,10 +9,12 @@
     "url": "https://github.com/Fernthedev/paperlog",
     "additionalData": {
       "overrideSoName": "libpaperlog.so",
-      "cmake": false,
       "compileOptions": {
-        "systemIncludes": ["shared/utfcpp/source"]
-      }
+        "systemIncludes": [
+          "shared/utfcpp/source"
+        ]
+      },
+      "cmake": false
     }
   },
   "workspace": {
@@ -25,12 +28,15 @@
       "qmod": [
         "pwsh ./scripts/createqmod.ps1 $0"
       ]
-    }
+    },
+    "qmodIncludeDirs": [],
+    "qmodIncludeFiles": [],
+    "qmodOutput": null
   },
   "dependencies": [
     {
       "id": "fmt",
-      "versionRange": "^10.0.0",
+      "versionRange": "^11.0.0",
       "additionalData": {}
     }
   ]

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -29,12 +29,15 @@
         "qmod": [
           "pwsh ./scripts/createqmod.ps1 $0"
         ]
-      }
+      },
+      "qmodIncludeDirs": [],
+      "qmodIncludeFiles": [],
+      "qmodOutput": null
     },
     "dependencies": [
       {
         "id": "fmt",
-        "versionRange": "^10.0.0",
+        "versionRange": "^11.0.0",
         "additionalData": {}
       }
     ]
@@ -43,10 +46,10 @@
     {
       "dependency": {
         "id": "fmt",
-        "versionRange": "=10.0.0",
+        "versionRange": "=11.0.2",
         "additionalData": {
           "headersOnly": true,
-          "branchName": "version/v10_0_0",
+          "branchName": "version/v11_0_2",
           "compileOptions": {
             "systemIncludes": [
               "fmt/include/"
@@ -57,7 +60,7 @@
           }
         }
       },
-      "version": "10.0.0"
+      "version": "11.0.2"
     }
   ]
 }

--- a/shared/feature/modinfo_fmt.hpp
+++ b/shared/feature/modinfo_fmt.hpp
@@ -2,7 +2,7 @@
 
 #ifndef NO_MODLOADER_FORMAT
 
-#include <fmt/format.h>
+#include <fmt/base.h>
 
 #include "modloader/shared/modloader.hpp"
 

--- a/shared/log_level.hpp
+++ b/shared/log_level.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <fmt/format.h>
+#include <fmt/base.h>
 #include <string_view>
 
 namespace Paper {

--- a/shared/logger.hpp
+++ b/shared/logger.hpp
@@ -6,7 +6,8 @@
 
 #include "_config.h"
 #include <chrono>
-#include <fmt/core.h>
+#include <fmt/base.h>
+#include <fmt/xchar.h>
 #include <thread>
 #include <type_traits>
 #include "log_level.hpp"
@@ -98,7 +99,7 @@ struct BasicFmtStrSrcLoc {
 
 //    template <typename... Args>
 //    using FmtStrSrcLoc = BasicFmtStrSrcLoc<char, fmt::type_identity_t<Args>...>;
-template <typename... Args> using FmtStrSrcLoc = BasicFmtStrSrcLoc<char, fmt::type_identity_t<Args>...>;
+template <typename... Args> using FmtStrSrcLoc = BasicFmtStrSrcLoc<char, std::type_identity_t<Args>...>;
 
 ///
 /// @param originalString This param exists since strings can be splitted due to newlines etc.
@@ -142,7 +143,7 @@ inline void vfmtLog(fmt::string_view const str, LogLevel level, sl const& source
 
 template <LogLevel lvl, typename... TArgs>
 constexpr auto fmtLogTag(FmtStrSrcLoc<TArgs...> str, std::string_view const tag, TArgs&&... args) {
-  return Logger::vfmtLog(str, lvl, str.sourceLocation, tag, fmt::make_format_args(std::forward<TArgs>(args)...));
+  return Logger::vfmtLog(str, lvl, str.sourceLocation, tag, fmt::make_format_args(args...));
 }
 
 template <LogLevel lvl, typename... TArgs> constexpr auto fmtLog(FmtStrSrcLoc<TArgs...> str, TArgs&&... args) {


### PR DESCRIPTION
Uses `fmt/base.h` instead of `fmt/core.h` for improved compile times
Use `std::type_identity_t` as fmt's version was removed