### PR TITLE
Include <sstream>

### DIFF
--- a/shared/backtrace.hpp
+++ b/shared/backtrace.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <optional>
 #include <string_view>
+#include <sstream>
 
 #include "logger.hpp"
 


### PR DESCRIPTION
Fixes the following.

error: implicit instantiation of undefined template 'std::basic_stringstream<char>'